### PR TITLE
Include stable versions of org.slf4j and logback

### DIFF
--- a/opentracing-benchmark-java-jaxrs/pom.xml
+++ b/opentracing-benchmark-java-jaxrs/pom.xml
@@ -1,307 +1,282 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>io.opentracing.contrib</groupId>
-	<artifactId>opentracing-benchmark-java-jaxrs</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<packaging>jar</packaging>
+    <groupId>io.opentracing.contrib</groupId>
+    <artifactId>opentracing-benchmark-java-jaxrs</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
-	<name>opentracing-benchmark-java-jaxrs</name>
-	<description>This project contains benchmark tests of opentracing java jax-rs.
-		The jax-rx example is based on: https://github.com/tachuela700/course-management
-	</description>
+    <name>opentracing-benchmark-java-jaxrs</name>
+    <description>This project contains benchmark tests of opentracing java jax-rs.
+        The jax-rx example is based on: https://github.com/tachuela700/course-management
+    </description>
 
-	<dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>2.0.0-alpha1</version>
-        </dependency>
-        <dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jul-to-slf4j</artifactId>
-			<version>2.0.0-alpha1</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>log4j-over-slf4j</artifactId>
-			<version>2.0.0-alpha1</version>
-		</dependency>
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<version>1.3.0-alpha5</version>
-		</dependency>
-    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.30</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
+                <version>1.7.30</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>log4j-over-slf4j</artifactId>
+                <version>1.7.30</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.2.3</version>
+            </dependency>
+        </dependencies>
     </dependencyManagement>
 
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.0</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.5.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
 
-	<properties>
-		<!-- encoding properties -->
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <properties>
+        <!-- encoding properties -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<!-- compilation properties -->
-		<java.version>14</java.version>
-		<maven.compiler.source>${java.version}</maven.compiler.source>
-		<maven.compiler.target>${java.version}</maven.compiler.target>
+        <!-- compilation properties -->
+        <java.version>14</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
 
 
-		<!--
+        <!--
             JMH version to use with this project.
           -->
-		<jmh.version>1.32</jmh.version>
-		<!--
+        <jmh.version>1.32</jmh.version>
+        <!--
             Name of the benchmark Uber-JAR to generate.
           -->
-		<uberjar.name>benchmarks</uberjar.name>
-		<!--
+        <uberjar.name>benchmarks</uberjar.name>
+        <!--
             Opentracing version
           -->
-		<opentracing.version>0.33.0</opentracing.version>
-		<opentracing.jaxrs2.discovery.version>1.0.0</opentracing.jaxrs2.discovery.version>
-		<!--
+        <opentracing.version>0.33.0</opentracing.version>
+        <opentracing.jaxrs2.discovery.version>1.0.0</opentracing.jaxrs2.discovery.version>
+        <!--
             Jaeger version
           -->
-		<jaeger.version>1.6.0</jaeger.version>
-		<haystack.version>0.4.0</haystack.version>
-		<unirest.version>1.4.9</unirest.version>
-	</properties>
+        <jaeger.version>1.6.0</jaeger.version>
+        <haystack.version>0.4.0</haystack.version>
+        <unirest.version>1.4.9</unirest.version>
+    </properties>
 
-	<dependencies>
-		<!-- Spring -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-jersey</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-
-		<!-- MyBatis -->
-		<dependency>
-			<groupId>org.mybatis.spring.boot</groupId>
-			<artifactId>mybatis-spring-boot-starter</artifactId>
-			<version>2.2.0</version>
-		</dependency>
+    <dependencies>
+        <!-- Spring -->
         <dependency>
-  			<groupId>junit</groupId>
-  			<artifactId>junit</artifactId>
-  			<version>4.13.2</version>
-  			<scope>test</scope>
-		</dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jersey</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
 
-		<!-- Logging moved to dependency management-->
-		
+        <!-- MyBatis -->
+        <dependency>
+            <groupId>org.mybatis.spring.boot</groupId>
+            <artifactId>mybatis-spring-boot-starter</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
 
-		<!-- Optional -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-	        <optional>true</optional>
-		</dependency>
+        <!-- Logging moved to dependency management-->
 
-		<dependency>
-			<groupId>com.h2database</groupId>
- 			<artifactId>h2</artifactId>
-		</dependency>
 
-		<!-- Testing -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+        <!-- Optional -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <optional>true</optional>
+        </dependency>
 
-		<!-- Opentracing -->
-		<dependency>
-			<groupId>org.openjdk.jmh</groupId>
-			<artifactId>jmh-core</artifactId>
-			<version>${jmh.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmh</groupId>
-			<artifactId>jmh-generator-annprocess</artifactId>
-			<version>${jmh.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<!-- Opentracing-->
-		<dependency>
-			<groupId>io.opentracing</groupId>
-			<artifactId>opentracing-api</artifactId>
-			<version>${opentracing.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.opentracing</groupId>
-			<artifactId>opentracing-noop</artifactId>
-			<version>${opentracing.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.opentracing</groupId>
-			<artifactId>opentracing-mock</artifactId>
-			<version>${opentracing.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.jaegertracing</groupId>
-			<artifactId>jaeger-client</artifactId>
-			<version>${jaeger.version}</version>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/io.opentracing.contrib/opentracing-jaxrs2-discovery -->
-		<dependency>
-			<groupId>io.opentracing.contrib</groupId>
-			<artifactId>opentracing-jaxrs2-discovery</artifactId>
-			<version>${opentracing.jaxrs2.discovery.version}</version>
-		</dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
 
-		<!-- https://mvnrepository.com/artifact/com.expedia.www/haystack-client-java-integrations -->
-		<dependency>
-			<groupId>com.expedia.www</groupId>
-			<artifactId>haystack-client-core</artifactId>
-			<version>${haystack.version}</version>
-		</dependency>
-		<!-- Http client -->
-		<dependency>
-			<groupId>com.mashape.unirest</groupId>
-			<artifactId>unirest-java</artifactId>
-			<version>${unirest.version}</version>
-		</dependency>
-	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.2.4</version>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<finalName>${uberjar.name}</finalName>
-							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-									<resource>META-INF/spring.handlers</resource>
-								</transformer>
-								<transformer implementation="org.springframework.boot.maven.PropertiesMergingResourceTransformer">
-									<resource>META-INF/spring.factories</resource>
-								</transformer>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-									<resource>META-INF/spring.schemas</resource>
-								</transformer>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>io.opentracing.contrib.benchmarks.main.Main</mainClass>
-								</transformer>
-							</transformers>
-							<filters>
-								<filter>
-									<!--
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Opentracing -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Opentracing-->
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <version>${opentracing.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-noop</artifactId>
+            <version>${opentracing.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+            <version>${opentracing.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jaegertracing</groupId>
+            <artifactId>jaeger-client</artifactId>
+            <version>${jaeger.version}</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/io.opentracing.contrib/opentracing-jaxrs2-discovery -->
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-jaxrs2-discovery</artifactId>
+            <version>${opentracing.jaxrs2.discovery.version}</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.expedia.www/haystack-client-java-integrations -->
+        <dependency>
+            <groupId>com.expedia.www</groupId>
+            <artifactId>haystack-client-core</artifactId>
+            <version>${haystack.version}</version>
+        </dependency>
+        <!-- Http client -->
+        <dependency>
+            <groupId>com.mashape.unirest</groupId>
+            <artifactId>unirest-java</artifactId>
+            <version>${unirest.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${uberjar.name}</finalName>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring.handlers</resource>
+                                </transformer>
+                                <transformer
+                                        implementation="org.springframework.boot.maven.PropertiesMergingResourceTransformer">
+                                    <resource>META-INF/spring.factories</resource>
+                                </transformer>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring.schemas</resource>
+                                </transformer>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>io.opentracing.contrib.benchmarks.main.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <!--
                                     Shading signed JARs will fail without this.
                                     http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
                                     -->
-									<artifact>*:*</artifact>
-									<excludes>
-										<exclude>META-INF/*.SF</exclude>
-										<exclude>META-INF/*.DSA</exclude>
-										<exclude>META-INF/*.RSA</exclude>
-									</excludes>
-								</filter>
-							</filters>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<artifactId>maven-clean-plugin</artifactId>
-					<version>2.5</version>
-				</plugin>
-				<plugin>
-					<artifactId>maven-deploy-plugin</artifactId>
-					<version>2.8.1</version>
-				</plugin>
-				<plugin>
-					<artifactId>maven-install-plugin</artifactId>
-					<version>2.5.1</version>
-				</plugin>
-				<plugin>
-					<artifactId>maven-jar-plugin</artifactId>
-					<version>2.4</version>
-				</plugin>
-				<plugin>
-					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.9.1</version>
-				</plugin>
-				<plugin>
-					<artifactId>maven-resources-plugin</artifactId>
-					<version>2.6</version>
-				</plugin>
-				<plugin>
-					<artifactId>maven-site-plugin</artifactId>
-					<version>3.3</version>
-				</plugin>
-				<plugin>
-					<artifactId>maven-source-plugin</artifactId>
-					<version>2.2.1</version>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-	</build>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>2.5</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.9.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.3</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.2.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>
-
-<!-- Error log received on run -->
-<!-- <! 2021-05-28 14:38:10.717 ERROR 6188 [nio-8080-exec-6] o.a.c.c.C.[Tomcat].[localhost].[/]       : Servlet.init() for servlet [io.opentracing.contrib.benchmarks.config.JerseyConfiguration] threw exception
-
-java.lang.IllegalStateException: The resource configuration is not modifiable in this context.
-        at org.glassfish.jersey.server.ResourceConfig$ImmutableState.register(ResourceConfig.java:248) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.glassfish.jersey.server.ResourceConfig$ImmutableState.register(ResourceConfig.java:195) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.glassfish.jersey.server.ResourceConfig.register(ResourceConfig.java:428) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.glassfish.jersey.servlet.WebComponent.<init>(WebComponent.java:306) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.glassfish.jersey.servlet.ServletContainer.init(ServletContainer.java:154) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.glassfish.jersey.servlet.ServletContainer.init(ServletContainer.java:347) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at javax.servlet.GenericServlet.init(GenericServlet.java:158) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.apache.catalina.core.StandardWrapper.initServlet(StandardWrapper.java:1134) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.apache.catalina.core.StandardWrapper.allocate(StandardWrapper.java:777) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:135) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:97) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:542) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:143) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:78) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:357) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:374) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:893) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1707) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) ~[na:na]
-        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) ~[na:na]
-        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61) ~[benchmarks.jar:1.0.0-SNAPSHOT]
-        at java.base/java.lang.Thread.run(Thread.java:831) ~[na:na]> -->


### PR DESCRIPTION
No need to merge it. Logs of benchmark tests [here](https://gist.githubusercontent.com/gsoria/dffbd7d05d5598e5891effc33846dfeb/raw/a6808e7ede85de9da24d05801b1097ac82a6ba03/jaxrx-logs).

Signed-off-by: Gabriela S. Soria <soria.gaby@gmail.com>